### PR TITLE
fix get_cudnn and get_tensorrt not detecting multi-digit version numbers correctly

### DIFF
--- a/script/get-cudnn/customize.py
+++ b/script/get-cudnn/customize.py
@@ -109,7 +109,7 @@ def preprocess(i):
     my_tar.close()
 
     import re
-    version_match = re.match(r'cudnn-.*?-(\d.\d.\d.\d)', folder_name)
+    version_match = re.match(r'cudnn-.*?-(\d+.\d+.\d+.\d+)', folder_name)
     if not version_match:
         return {'return': 1, 'error': 'Extracted CUDNN folder does not seem proper - Version information missing'}
     version = version_match.group(1)

--- a/script/get-tensorrt/customize.py
+++ b/script/get-tensorrt/customize.py
@@ -100,7 +100,7 @@ def preprocess(i):
     my_tar.close()
 
     import re
-    version_match = re.match(r'TensorRT-(\d.\d.\d.\d)', folder_name)
+    version_match = re.match(r'TensorRT-(\d+.\d+.\d+.\d+)', folder_name)
     if not version_match:
         return {'return': 1, 'error': 'Extracted TensorRT folder does not seem proper - Version information missing'}
     version = version_match.group(1)


### PR DESCRIPTION
Cudnn and Tensorrt can have multi-digit major and minor version numbers like TensorRT-10.5.0.18.
The detection was not compatible with those