### PR TITLE
enable get_cudnn to detect cudnn in $CUDNN_ROOT

### DIFF
--- a/script/get-cudnn/customize.py
+++ b/script/get-cudnn/customize.py
@@ -69,6 +69,7 @@ def preprocess(i):
                 if cm_tmp_path != '':
                     cm_tmp_path += ':'
                 cm_tmp_path += '/usr/local/cuda/lib64:/usr/cuda/lib64:/usr/local/cuda/lib:/usr/cuda/lib:/usr/local/cuda-11/lib64:/usr/cuda-11/lib:/usr/local/cuda-12/lib:/usr/cuda-12/lib:/usr/local/packages/cuda/lib'
+                cm_tmp_path += os.path.expandvars(':$CUDNN_ROOT/lib')
                 env['CM_TMP_PATH'] = cm_tmp_path
                 env['CM_TMP_PATH_IGNORE_NON_EXISTANT'] = 'yes'
 


### PR DESCRIPTION
If cudnn is managed by modules, it can occur that only $CUDNN_ROOT gets set on "module load". get_cudnn did not search this path.